### PR TITLE
Use taurusmodelselector in TaurusItemConfDlg class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ platforms = ['Linux', 'Windows']
 keywords = ['Taurus', 'pyqtgraph', 'plugin', 'widgets']
 
 install_requires = [
-    'taurus>=4.3.0',
+    'taurus>=4.5.2',
     'taurus[taurus-qt]',
     'pyqtgraph',
 ]

--- a/taurus_pyqtgraph/curvesmodel.py
+++ b/taurus_pyqtgraph/curvesmodel.py
@@ -31,7 +31,9 @@ curvesmodel Model and view for new CurveItem configuration
 """
 __all__ = ['TaurusCurveItemTableModel', 'TaurusItemConf', 'TaurusItemConfDlg']
 
+import sys
 import copy
+import pkg_resources
 
 from taurus.external.qt import Qt
 
@@ -40,7 +42,7 @@ from taurus.core import TaurusElementType
 from taurus.qt.qtcore.mimetypes import (TAURUS_MODEL_LIST_MIME_TYPE,
                                         TAURUS_ATTR_MIME_TYPE)
 from taurus.qt.qtgui.util.ui import UILoadable
-
+from taurus.qt.qtgui.panel import TaurusModelSelector
 
 # columns:
 NUMCOLS = 3
@@ -322,8 +324,6 @@ class TaurusItemConfDlg(Qt.QWidget):
                 TaurusItemConf(YModel=None, XModel=None, name=None)
             ]
 
-        self.ui.tangoTree.setButtonsPos(Qt.Qt.RightToolBarArea)
-
         # @todo: The action for this button is not yet implemented
         self.ui.reloadBT.setEnabled(False)
 
@@ -340,19 +340,16 @@ class TaurusItemConfDlg(Qt.QWidget):
         import taurus
         # -------------------------------------------------------------------
 
-        try:  # TODO: Tango-centric!
-            host = taurus.Factory('tango').getAuthority().getFullName()
-            self.ui.tangoTree.setModel(host)
-        except Exception as e:
-            taurus.info('Cannot populate Tango Tree: %r', e)
+        modelSelector = TaurusModelSelector(parent=self)
+        self.ui.verticalLayout.addWidget(modelSelector)
 
         # Connections
         self.ui.applyBT.clicked.connect(self.onApply)
         self.ui.reloadBT.clicked.connect(self.onReload)
         self.ui.cancelBT.clicked.connect(self.close)
-        self.ui.tangoTree.addModels.connect(self.onModelsAdded)
         self.ui.curvesTable.customContextMenuRequested.connect(
             self.onTableContextMenu)
+        modelSelector.modelsAdded.connect(self.onModelsAdded)
 
     def onTableContextMenu(self, pos):
         index = self.ui.curvesTable.indexAt(pos)

--- a/taurus_pyqtgraph/ui/TaurusItemConfDlg.ui
+++ b/taurus_pyqtgraph/ui/TaurusItemConfDlg.ui
@@ -1,78 +1,65 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>TaurusItemConfDlg</class>
- <widget class="QWidget" name="TaurusItemConfDlg" >
-  <property name="geometry" >
+ <widget class="QWidget" name="TaurusItemConfDlg">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>812</width>
+    <width>850</width>
     <height>495</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" >
-   <item row="0" column="0" >
-    <widget class="QSplitter" name="splitter" >
-     <property name="orientation" >
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QGroupBox" name="groupBox_2" >
-      <property name="title" >
+     <widget class="QGroupBox" name="groupBox_2">
+      <property name="title">
        <string>Sources of data</string>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_5" >
+      <layout class="QVBoxLayout" name="verticalLayout_5">
        <item>
-        <widget class="QTabWidget" name="tabWidget" >
-         <property name="currentIndex" >
-          <number>0</number>
-         </property>
-         <widget class="QWidget" name="tangoTab" >
-          <attribute name="title" >
-           <string>Tango</string>
-          </attribute>
-          <layout class="QHBoxLayout" name="horizontalLayout_4" >
-           <item>
-            <widget class="TaurusModelSelectorTree" name="tangoTree" />
-           </item>
-          </layout>
-         </widget>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout"/>
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="groupBox_3" >
-      <property name="title" >
+     <widget class="QGroupBox" name="groupBox_3">
+      <property name="title">
        <string>Contents &amp; appearance</string>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_7" >
+      <layout class="QVBoxLayout" name="verticalLayout_7">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4" >
+        <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QTableView" name="curvesTable" >
-           <property name="minimumSize" >
+          <widget class="QTableView" name="curvesTable">
+           <property name="minimumSize">
             <size>
              <width>400</width>
              <height>0</height>
             </size>
            </property>
-           <property name="contextMenuPolicy" >
+           <property name="contextMenuPolicy">
             <enum>Qt::CustomContextMenu</enum>
            </property>
-           <property name="dragDropMode" >
+           <property name="dragDropMode">
             <enum>QAbstractItemView::DragDrop</enum>
            </property>
           </widget>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2" >
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
-            <spacer name="horizontalSpacer" >
-             <property name="orientation" >
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
-             <property name="sizeHint" stdset="0" >
+             <property name="sizeHint" stdset="0">
               <size>
                <width>40</width>
                <height>20</height>
@@ -81,17 +68,17 @@
             </spacer>
            </item>
            <item>
-            <widget class="QToolButton" name="removeCurvesBT" >
-             <property name="contextMenuPolicy" >
+            <widget class="QToolButton" name="removeCurvesBT">
+             <property name="contextMenuPolicy">
               <enum>Qt::NoContextMenu</enum>
              </property>
-             <property name="text" >
+             <property name="text">
               <string> Remove</string>
              </property>
-             <property name="popupMode" >
+             <property name="popupMode">
               <enum>QToolButton::MenuButtonPopup</enum>
              </property>
-             <property name="toolButtonStyle" >
+             <property name="toolButtonStyle">
               <enum>Qt::ToolButtonTextBesideIcon</enum>
              </property>
             </widget>
@@ -104,14 +91,14 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <layout class="QHBoxLayout" name="horizontalLayout_3" >
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <spacer name="horizontalSpacer_2" >
-       <property name="orientation" >
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -120,22 +107,22 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="reloadBT" >
-       <property name="text" >
+      <widget class="QPushButton" name="reloadBT">
+       <property name="text">
         <string>Reload</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cancelBT" >
-       <property name="text" >
+      <widget class="QPushButton" name="cancelBT">
+       <property name="text">
         <string>Cancel</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="applyBT" >
-       <property name="text" >
+      <widget class="QPushButton" name="applyBT">
+       <property name="text">
         <string>Apply</string>
        </property>
       </widget>
@@ -144,13 +131,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>TaurusModelSelectorTree</class>
-   <extends>TaurusWidget</extends>
-   <header>taurus.qt.qtgui.panel</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Modify TaurusItemConfDlg class to use TaurusModelSelector class
instead a custom Tango model chooser.

It requires Taurus >= 4.5.2 (PR https://github.com/taurus-org/taurus/pull/869)