### PR TITLE
Catch exception in TaurusPlotDataItem handleEvent method

### DIFF
--- a/taurus_pyqtgraph/taurusplotdataitem.py
+++ b/taurus_pyqtgraph/taurusplotdataitem.py
@@ -88,7 +88,7 @@ class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
         try:
             self.setData(x=self._x, y=self._y)
         except Exception, e:
-            self.debug(repr(e))
+            self.debug('Could not set data. Reason: %r', e)
 
     def getOpts(self):
         from taurus.qt.qtgui.tpg import serialize_opts

--- a/taurus_pyqtgraph/taurusplotdataitem.py
+++ b/taurus_pyqtgraph/taurusplotdataitem.py
@@ -85,7 +85,10 @@ class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
             self._y = evt_value.rvalue
         if self.xModel == evt_src and self.xModel is not None:
             self._x = evt_value.rvalue
-        self.setData(x=self._x, y=self._y)
+        try:
+            self.setData(x=self._x, y=self._y)
+        except Exception, e:
+            self.debug(repr(e))
 
     def getOpts(self):
         from taurus.qt.qtgui.tpg import serialize_opts


### PR DESCRIPTION
If a X or Y model is set. It can cause an exception when
the new event data is applied.

e.g. x and w have different shape

Catch exception and report a debug message.