### PR TITLE
TaurusTrendSet is not protected for unavailable models

### DIFF
--- a/taurus_pyqtgraph/taurustrendset.py
+++ b/taurus_pyqtgraph/taurustrendset.py
@@ -334,7 +334,7 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
                       all.
         """
         value = self.getModelValueObj(cache=cache)
-        if cache:
+        if cache and value is not None:
             value = copy.copy(value)
             value.time = TaurusTimeVal.now()
         self.fireEvent(self, TaurusEventType.Periodic, value)


### PR DESCRIPTION
Verify that getModelValueObj returns an object before overide
the time in TaurusTrendSet._forceRead method.

Fix #21