### PR TITLE
Do not complain if rvalue is not part of evt_val (=DevFail)

### DIFF
--- a/taurus_pyqtgraph/taurusimageitem.py
+++ b/taurus_pyqtgraph/taurusimageitem.py
@@ -41,6 +41,9 @@ class TaurusImageItem(ImageItem, TaurusBaseComponent):
         TaurusBaseComponent.__init__(self, "TaurusImageItem")
 
     def handleEvent(self, evt_src, evt_type, evt_val):
+        if evt_val is None or getattr(evt_val, 'rvalue', None) is None:
+            self.debug('Ignoring event from %s' % repr(evt_src))
+            return
         try:
             data = evt_val.rvalue
             self.setImage(data)

--- a/taurus_pyqtgraph/taurusimageitem.py
+++ b/taurus_pyqtgraph/taurusimageitem.py
@@ -42,7 +42,7 @@ class TaurusImageItem(ImageItem, TaurusBaseComponent):
 
     def handleEvent(self, evt_src, evt_type, evt_val):
         if evt_val is None or getattr(evt_val, 'rvalue', None) is None:
-            self.debug('Ignoring event from %s' % repr(evt_src))
+            self.debug('Ignoring empty value event from %s' % repr(evt_src))
             return
         try:
             data = evt_val.rvalue


### PR DESCRIPTION
This is just a backport from TaurusBaseImage used with the Taurus gwt implementation.

It reduce a lot the noises when devices are not there.