### PR TITLE
Register plot and trend widgets for taurus alt

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    # Ignore deprecation warnings issued by 3rd party modules
+    ignore:.*:DeprecationWarning:^(?!taurus_pyqtgraph).*$
+    # Treat taurus_pyqtgraph issued warnings as errors
+    error:.*:Warning:^taurus_pyqtgraph.*$

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ test_requirements = ["pytest"]
 entry_points = {
     "taurus.qt.qtgui": ["tpg = taurus_pyqtgraph"],
     "taurus.cli.subcommands": ["tpg = taurus_pyqtgraph.cli:tpg"],
-    "taurus.alt.plot": ["tpg = taurus_pyqtgraph:TaurusPlot"],
+    "taurus.plot.alts": ["tpg = taurus_pyqtgraph:TaurusPlot"],
+    "taurus.trend.alts": ["tpg = taurus_pyqtgraph:TaurusTrend"],
 }
 
 classifiers = [

--- a/taurus_pyqtgraph/cli.py
+++ b/taurus_pyqtgraph/cli.py
@@ -23,87 +23,32 @@
 
 import pkg_resources
 import click
+import sys
 
 _tpg_version = pkg_resources.require("taurus_pyqtgraph")[0].version
 _taurus_version = pkg_resources.require("taurus")[0].version
 _version = "{0} (with taurus {1})".format(_tpg_version, _taurus_version)
 
 
-@click.group("tpg")
-@click.version_option(version=_version, prog_name="tpg")
+@click.group('tpg')
 def tpg():
-    """Taurus-pyqtgraph related commands"""
-    pass
+    """[DEPRECATED] use "taurus plot" or "taurus trend" instead"""
+    print('"taurus tpg" subcommand is deprecated. '
+          + 'Use "taurus plot" or "taurus trend" instead\n')
+    sys.exit(1)
 
 
-@tpg.command("plot")
-@click.argument("models", nargs=-1)
-@click.option(
-    "--config",
-    "config_file",
-    type=click.File(),
-    help="configuration file for initialization",
-)
-@click.option(
-    "-x",
-    "--x-axis-mode",
-    "x_axis_mode",
-    type=click.Choice(["t", "n"]),
-    default="n",
-    show_default=True,
-    help=(
-        'X axis mode. "t" implies using a Date axis'
-        + '"n" uses the regular axis'
-    ),
-)
-@click.option("--demo", is_flag=True, help="show a demo of the widget")
-@click.option(
-    "--window-name",
-    "window_name",
-    default="TaurusPlot (pg)",
-    help="Name of the window",
-)
-def plot_cmd(models, config_file, x_axis_mode, demo, window_name):
-    """Shows a plot for the given models"""
-    from .plot import plot_main
-
-    return plot_main(
-        models=models,
-        config_file=config_file,
-        x_axis_mode=x_axis_mode,
-        demo=demo,
-        window_name=window_name,
-    )
+@tpg.command()
+def plot():
+    """[DEPRECATED] use "taurus plot" instead"""
+    sys.exit(1)
 
 
-@tpg.command("trend")
-@click.argument("models", nargs=-1)
-@click.option(
-    "--config",
-    "config_file",
-    type=click.File(),
-    help="configuration file for initialization",
-)
-@click.option("--demo", is_flag=True, help="show a demo of the widget")
-@click.option(
-    "--window-name",
-    "window_name",
-    default="TaurusPlot (pg)",
-    help="Name of the window",
-)
-def trend_cmd(models, config_file, demo, window_name):
-    """Shows a trend for the given models"""
-    from .trend import trend_main
-
-    return trend_main(
-        models=models,
-        config_file=config_file,
-        demo=demo,
-        window_name=window_name,
-    )
+@tpg.command()
+def trend():
+    """[DEPRECATED] use "taurus trend" instead"""
+    sys.exit(1)
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(tpg())  # pragma: no cover

--- a/taurus_pyqtgraph/plot.py
+++ b/taurus_pyqtgraph/plot.py
@@ -243,6 +243,19 @@ class TaurusPlot(PlotWidget, BaseConfigurableClass):
         del state["view"]["viewRange"]
         return state
 
+    def setXAxisMode(self, x_axis_mode):
+        """Required generic TaurusPlot API """
+        from taurus_pyqtgraph import DateAxisItem
+        if x_axis_mode == "t":
+            axis = DateAxisItem(orientation="bottom")
+            axis.attachToPlotItem(self.getPlotItem())
+        elif x_axis_mode == "n":
+            axis = self.getPlotItem().axes["bottom"]["item"]
+            if isinstance(axis, DateAxisItem):
+                axis.detachFromPlotItem()
+        else:
+            raise ValueError("Unsupported x axis mode {}".format(x_axis_mode))
+
 
 def plot_main(
     models=(),
@@ -267,11 +280,7 @@ def plot_main(
         models = list(models)
         models.extend(["eval:rand(100)", "eval:0.5*sqrt(arange(100))"])
 
-    if x_axis_mode.lower() == "t":
-        from taurus.qt.qtgui.tpg import DateAxisItem
-
-        axis = DateAxisItem(orientation="bottom")
-        axis.attachToPlotItem(w.getPlotItem())
+    w.setXAxisMode(x_axis_mode.lower())
 
     if config_file is not None:
         w.loadConfigFile(config_file)

--- a/taurus_pyqtgraph/trend.py
+++ b/taurus_pyqtgraph/trend.py
@@ -130,8 +130,8 @@ class TaurusTrend(PlotWidget, BaseConfigurableClass):
         inspector_tool.attachToPlotItem(self.getPlotItem())
 
         # add force read tool
-        fr_tool = ForcedReadTool(self)
-        fr_tool.attachToPlotItem(self.getPlotItem())
+        self._fr_tool = ForcedReadTool(self)
+        self._fr_tool.attachToPlotItem(self.getPlotItem())
 
         # Add the auto-pan ("oscilloscope mode") tool
         autopan = XAutoPanTool()
@@ -140,7 +140,7 @@ class TaurusTrend(PlotWidget, BaseConfigurableClass):
         # Register config properties
         self.registerConfigDelegate(self._y2, "Y2Axis")
         self.registerConfigDelegate(legend_tool, "legend")
-        self.registerConfigDelegate(fr_tool, "forceread")
+        self.registerConfigDelegate(self._fr_tool, "forceread")
         self.registerConfigDelegate(inspector_tool, "inspector")
 
     # --------------------------------------------------------------------
@@ -259,6 +259,23 @@ class TaurusTrend(PlotWidget, BaseConfigurableClass):
         # remove viewRange conf
         del state["view"]["viewRange"]
         return state
+
+    def setXAxisMode(self, x_axis_mode):
+        """Required generic TaurusTrend API """
+        if x_axis_mode != "t":
+            raise NotImplementedError(  # TODO
+                'X mode "{}" not yet supported'.format(x_axis_mode)
+            )
+
+    def setForcedReadingPeriod(self, period):
+        """Required generic TaurusTrend API """
+        self._fr_tool.setPeriod(period)
+
+    def setMaxDataBufferSize(self, buffer_size):
+        """Required generic TaurusTrend API """
+        raise NotImplementedError(  # TODO
+            "Setting the max buffer size is not yet supported by tpg trend"
+        )
 
 
 def trend_main(

--- a/tests/test_taurus_pyqtgraph.py
+++ b/tests/test_taurus_pyqtgraph.py
@@ -18,7 +18,7 @@ def test_command_line_interface():
     runner = CliRunner()
     result = runner.invoke(cli.tpg)
     assert result.exit_code == 0
-    assert "Taurus-pyqtgraph related commands" in result.output
+    assert '[DEPRECATED] use "taurus plot" or "taurus trend" instead' in result.output
     help_result = runner.invoke(cli.tpg, ["--help"])
     assert help_result.exit_code == 0
     assert "Show this message and exit." in help_result.output


### PR DESCRIPTION
Adapt `taurus_pyqtgraph` to changes introduced in https://github.com/taurus-org/taurus/pull/1120 : 

- remove the tpg subcommand 
- register TaurusPlot and TaurusTrend as alternative implementations for plot and trend respectively.

Note: this PR needs to be evaluated together with  taurus-org/taurus#1120