### PR TITLE
Make colors of trend curves different  among trendsets

### DIFF
--- a/taurus_pyqtgraph/curveproperties.py
+++ b/taurus_pyqtgraph/curveproperties.py
@@ -46,6 +46,7 @@ __all__ = [
     "get_properties_from_curves",
     "set_properties_on_curves",
     "set_y_axis_for_curve",
+    "CURVE_COLORS",
 ]
 
 import copy
@@ -54,7 +55,7 @@ from taurus import warning
 from taurus.external.qt import Qt
 from taurus.core.util.containers import CaselessDict
 from taurus.qt.qtgui.util.ui import UILoadable
-from taurus_pyqtgraph.y2axis import Y2ViewBox, set_y_axis_for_curve
+from .y2axis import Y2ViewBox, set_y_axis_for_curve
 import pyqtgraph
 
 
@@ -117,16 +118,45 @@ for k, v in NamedSymbolStyles.items():
     ReverseNamedSymbolStyles[v] = k
 
 NamedColors = [
-    "Black",
     "Red",
     "Blue",
-    "Magenta",
     "Green",
+    "Magenta",
     "Cyan",
     "Yellow",
+    "Orange",
+    "greenyellow",
     "Gray",
     "White",
+    "Black",
 ]
+
+kelly_colors_hex = [  # https://stackoverflow.com/a/4382138
+    0xFFB300,  # Vivid Yellow
+    0x803E75,  # Strong Purple
+    0xFF6800,  # Vivid Orange
+    0xA6BDD7,  # Very Light Blue
+    0xC10020,  # Vivid Red
+    0xCEA262,  # Grayish Yellow
+    0x817066,  # Medium Gray
+    # The following don't work well for people with defective color vision
+    0x007D34,  # Vivid Green
+    0xF6768E,  # Strong Purplish Pink
+    0x00538A,  # Strong Blue
+    # 0xFF7A5C, # Strong Yellowish Pink
+    # 0x53377A, # Strong Violet
+    # 0xFF8E00, # Vivid Orange Yellow
+    0xB32851,  # Strong Purplish Red
+    # 0xF4C800, # Vivid Greenish Yellow
+    # 0x7F180D, # Strong Reddish Brown
+    0x93AA00,  # Vivid Yellowish Green
+    0x593315,  # Deep Yellowish Brown
+    # 0xF13A13, # Vivid Reddish Orange
+    # 0x232C16, # Dark Olive Green
+]
+
+CURVE_COLORS = [Qt.QColor(n) for n in NamedColors[:-2]]
+# CURVE_COLORS = [Qt.QColor(n) for n in kelly_colors_hex]
 
 
 @UILoadable
@@ -174,7 +204,7 @@ class CurvesAppearanceChooser(Qt.QWidget):
         if not showButtons:
             self.applyBT.hide()
             self.resetBT.hide()
-        for color in NamedColors:
+        for color in CURVE_COLORS:
             icon = self._colorIcon(color)
             self.sColorCB.addItem(icon, "", Qt.QColor(color))
             self.lColorCB.addItem(icon, "", Qt.QColor(color))

--- a/taurus_pyqtgraph/plot.py
+++ b/taurus_pyqtgraph/plot.py
@@ -41,16 +41,7 @@ from .taurusmodelchoosertool import TaurusXYModelChooserTool
 from .legendtool import PlotLegendTool
 from .datainspectortool import DataInspectorTool
 from .y2axis import Y2ViewBox
-
-CURVE_COLORS = [
-    Qt.QPen(Qt.Qt.red),
-    Qt.QPen(Qt.Qt.blue),
-    Qt.QPen(Qt.Qt.green),
-    Qt.QPen(Qt.Qt.magenta),
-    Qt.QPen(Qt.Qt.cyan),
-    Qt.QPen(Qt.Qt.yellow),
-    Qt.QPen(Qt.Qt.white),
-]
+from .curveproperties import CURVE_COLORS
 
 
 class TaurusPlot(PlotWidget, BaseConfigurableClass):

--- a/taurus_pyqtgraph/taurusmodelchoosertool.py
+++ b/taurus_pyqtgraph/taurusmodelchoosertool.py
@@ -457,9 +457,12 @@ class TaurusXYModelChooserTool(Qt.QAction, BaseConfigurableClass):
             else:
                 if cname is None:
                     cname = ymodel.getSimpleName()
-                item = self.itemClass(xModel=xname, yModel=yname, name=cname)
-                if self._curveColors is not None:
-                    item.setPen(self._curveColors.next().color())
+                item = self.itemClass(
+                    xModel=xname,
+                    yModel=yname,
+                    name=cname,
+                    colors=self._curveColors,
+                )
                 self.plot_item.addItem(item)
 
 

--- a/taurus_pyqtgraph/taurusplotdataitem.py
+++ b/taurus_pyqtgraph/taurusplotdataitem.py
@@ -29,6 +29,8 @@ from taurus import Attribute
 from taurus.core import TaurusEventType
 from taurus.qt.qtgui.base import TaurusBaseComponent
 from pyqtgraph import PlotDataItem
+from taurus.core.util.containers import LoopList
+from .curveproperties import CURVE_COLORS
 
 
 class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
@@ -41,9 +43,13 @@ class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
                        Default=None
         :param yModel: (str) Taurus model name for ordinate values.
                        Default=None
+        :param colors: (generator) An infinite generator of QColor objects
         """
         xModel = kwargs.pop("xModel", None)
         yModel = kwargs.pop("yModel", None)
+        colors = kwargs.pop("colors", LoopList(CURVE_COLORS))
+        if "pen" not in kwargs:
+            kwargs["pen"] = next(colors)
         PlotDataItem.__init__(self, *args, **kwargs)
         TaurusBaseComponent.__init__(self, "TaurusBaseComponent")
         self._x = None
@@ -97,7 +103,7 @@ class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
             self.debug("Could not set data. Reason: %r", e)
 
     def getOpts(self):
-        from taurus.qt.qtgui.tpg import serialize_opts
+        from taurus_pyqtgraph import serialize_opts
 
         return serialize_opts(copy.copy(self.opts))
 
@@ -105,7 +111,7 @@ class TaurusPlotDataItem(PlotDataItem, TaurusBaseComponent):
         # creates QPainters (QPen or QBrush) from a pickle loaded file
         # for adapt the serialized objects into PlotDataItem properties
 
-        from taurus.qt.qtgui.tpg import deserialize_opts
+        from taurus_pyqtgraph import deserialize_opts
 
         self.opts = deserialize_opts(opts)
 

--- a/taurus_pyqtgraph/taurustrendset.py
+++ b/taurus_pyqtgraph/taurustrendset.py
@@ -34,19 +34,10 @@ from taurus.core.util.containers import ArrayBuffer, LoopList
 from taurus.external.qt import Qt
 from pyqtgraph import PlotDataItem
 
-from taurus_pyqtgraph.forcedreadtool import ForcedReadTool
+from .forcedreadtool import ForcedReadTool
+from .curveproperties import CURVE_COLORS
 
 import taurus
-
-CURVE_COLORS = [
-    Qt.QPen(Qt.Qt.red),
-    Qt.QPen(Qt.Qt.blue),
-    Qt.QPen(Qt.Qt.green),
-    Qt.QPen(Qt.Qt.magenta),
-    Qt.QPen(Qt.Qt.cyan),
-    Qt.QPen(Qt.Qt.yellow),
-    Qt.QPen(Qt.Qt.white),
-]
 
 
 class TrendCurve(PlotDataItem):
@@ -83,16 +74,18 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
     object to update its values)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, colors=None, **kwargs):
         _ = kwargs.pop("xModel", None)
         yModel = kwargs.pop("yModel", None)
+        if colors is None:
+            colors = LoopList(CURVE_COLORS)
         PlotDataItem.__init__(self, *args, **kwargs)
         TaurusBaseComponent.__init__(self, "TaurusBaseComponent")
         self._UImodifiable = False
         self._maxBufferSize = 65536  # (=2**16, i.e., 64K events))
         self._xBuffer = None
         self._yBuffer = None
-        self._curveColors = LoopList(CURVE_COLORS)
+        self._curveColors = colors
         self._args = args
         self._kwargs = kwargs
         self._curves = []
@@ -166,7 +159,10 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
         self._updateViewBox(None)
 
         self._curves = []
-        self._curveColors.setCurrentIndex(-1)
+
+        if self._curveColors is None:
+            self._curveColors = LoopList(CURVE_COLORS)
+            self._curveColors.setCurrentIndex(-1)
 
         a = self._args
         kw = self._kwargs.copy()
@@ -181,7 +177,7 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
             kw["name"] = subname
             curve = TrendCurve(*a, **kw)
             if "pen" not in kw:
-                curve.setPen(self._curveColors.next().color())
+                curve.setPen(next(self._curveColors))
             self._curves.append(curve)
         self._updateViewBox(self.getViewBox())
 

--- a/taurus_pyqtgraph/trend.py
+++ b/taurus_pyqtgraph/trend.py
@@ -45,17 +45,7 @@ from .taurusmodelchoosertool import TaurusXYModelChooserTool
 from .taurustrendset import TaurusTrendSet
 from .y2axis import Y2ViewBox
 from .autopantool import XAutoPanTool
-
-
-CURVE_COLORS = [
-    Qt.QPen(Qt.Qt.red),
-    Qt.QPen(Qt.Qt.blue),
-    Qt.QPen(Qt.Qt.green),
-    Qt.QPen(Qt.Qt.magenta),
-    Qt.QPen(Qt.Qt.cyan),
-    Qt.QPen(Qt.Qt.yellow),
-    Qt.QPen(Qt.Qt.white),
-]
+from .curveproperties import CURVE_COLORS
 
 
 class TaurusTrend(PlotWidget, BaseConfigurableClass):


### PR DESCRIPTION
The color palette of each Trendset is independent of the other
trendsets, causing colors to be repeated among different
trendsets. Use a single palette so that color cycles are longer.
Also add a few more colors to the palette, and remove duplicated
code related to colors.

Fixes #41