### PR TITLE
add "clear curves" option to trends

### DIFF
--- a/taurus_pyqtgraph/trend.py
+++ b/taurus_pyqtgraph/trend.py
@@ -90,6 +90,11 @@ class TaurusTrend(PlotWidget, BaseConfigurableClass):
         plot_item = self.getPlotItem()
         menu = plot_item.getViewBox().menu
 
+        # add plot clear action
+        clearCurvesAction = QtGui.QAction("Clear plots", menu)
+        clearCurvesAction.triggered.connect(self.clearTrends)
+        menu.addAction(clearCurvesAction)
+
         # add save & retrieve configuration actions
         saveConfigAction = QtGui.QAction("Save configuration", menu)
         saveConfigAction.triggered.connect(self.saveConfigFile)
@@ -182,6 +187,11 @@ class TaurusTrend(PlotWidget, BaseConfigurableClass):
             for e in self.getPlotItem().listDataItems()
             if isinstance(e, TaurusTrendSet)
         ]
+
+    def clearTrends(self):
+        for e in self.getPlotItem().listDataItems():
+            if isinstance(e, TaurusTrendSet):
+                e._initBuffers(len(e))
 
     def setModel(self, names):
         """Set a list of models"""


### PR DESCRIPTION
Dear all,

I have not found an option to easily clear the trend displays. When we have them running for any extended period of time we end up manually zooming to the current point in time.

I have just started using taurus, so I may be missing something obvious here - sorry if I do!
In any case, I solved the problem locally by adding a command to the right-click menu. Again, I'm not sure how good/ horrible this solution is. Any feedback is much appreciated.

Cheers,

Michael