### PR TITLE
Avoid exception when averaging trends

### DIFF
--- a/taurus_pyqtgraph/taurustrendset.py
+++ b/taurus_pyqtgraph/taurustrendset.py
@@ -81,7 +81,8 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
         colors = kwargs.pop("colors", None)
         if colors is None:
             colors = LoopList(CURVE_COLORS)
-        PlotDataItem.__init__(self, *args, **kwargs)
+        # PlotDataItem.__init__(self, *args, **kwargs)
+        PlotDataItem.__init__(self, x=[], y=[])
         TaurusBaseComponent.__init__(self, "TaurusBaseComponent")
         self._UImodifiable = False
         self._maxBufferSize = 65536  # (=2**16, i.e., 64K events))
@@ -223,7 +224,9 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
                     plotItem = viewWidget.getPlotItem()
                 if plotItem is not None:
                     curve = ensure_unique_curve_name(curve, plotItem)
-                    plotItem.addItem(curve)
+                    _cname = curve.name()
+                    params = {"all trends": _cname}
+                    plotItem.addItem(curve, params=params)
 
     def _updateBuffers(self, evt_value):
         """Update the x and y buffers with the new data. If the new data is

--- a/taurus_pyqtgraph/taurustrendset.py
+++ b/taurus_pyqtgraph/taurustrendset.py
@@ -81,8 +81,8 @@ class TaurusTrendSet(PlotDataItem, TaurusBaseComponent):
         colors = kwargs.pop("colors", None)
         if colors is None:
             colors = LoopList(CURVE_COLORS)
-        # PlotDataItem.__init__(self, *args, **kwargs)
-        PlotDataItem.__init__(self, x=[], y=[])
+        name = kwargs.pop("name", None)
+        PlotDataItem.__init__(self, x=[], y=[], name=name)
         TaurusBaseComponent.__init__(self, "TaurusBaseComponent")
         self._UImodifiable = False
         self._maxBufferSize = 65536  # (=2**16, i.e., 64K events))


### PR DESCRIPTION
TaurusTrendSets consist on a dummy empty plotdataitem which composes
one or TrendCurve objects that show the actual data. The dummy item
has no x or y data set, and this creates issues with features such as
Average which do not properly check their inputs. Set an empty array
for the dummy x,y as a workaround.

Also, use a "all trends" parameter for the TrendCurve items so that
they can be selected as a group for averaging.

Note: as of writing, the "average" feature of pyqtgraph is quite
fragile and prone to errors. This is not fixing it, it just prevents
some annoying exceptions.

Fixes #73