### PR TITLE
Protect DateAxisItem.tickValues against overflows

### DIFF
--- a/.github/workflows/test_with_tox.yml
+++ b/.github/workflows/test_with_tox.yml
@@ -3,6 +3,7 @@ name: Test Package
 on: [push, pull_request]
 
 jobs:
+
   tox_tests:
     runs-on: ubuntu-latest
     strategy:
@@ -17,8 +18,13 @@ jobs:
       - name: Install Tox and any other packages
         run: pip install tox
       - name: Run Tox
+        if: ${{ matrix.python != '3.5' }}
         # Run tox using the version of Python in `PATH`
         run: tox -e py
+      - name: Run Tox for 3.5
+        if: ${{ matrix.python == '3.5' }}
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py35
 
   flake8_tests:
     runs-on: ubuntu-latest

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,4 +12,5 @@ pytest>=5
 pytest-runner>=4.2
 pytest-qt>=3.3
 pytest-xvfb>=2.0
+pytest-forked
 

--- a/taurus_pyqtgraph/dateaxisitem.py
+++ b/taurus_pyqtgraph/dateaxisitem.py
@@ -87,7 +87,7 @@ class DateAxisItem(AxisItem):
 
         if dx > 63072001:  # 3600s*24*(365+366) = 2 years (count leap year)
             d = timedelta(days=366)
-            for y in range(dt1.year + 1, dt2.year):
+            for y in range(dt1.year + 1, dt2.year + 1):
                 dt = datetime(year=y, month=1, day=1)
                 majticks.append(mktime(dt.timetuple()))
 
@@ -145,7 +145,10 @@ class DateAxisItem(AxisItem):
 
         elif dx > 2:  # 2s
             d = timedelta(seconds=1)
-            majticks = list(range(int(minVal), int(maxVal)))
+            # majticks = list(range(int(minVal), int(maxVal)))
+            majticks = list(
+                range(int(numpy.ceil(minVal)), int(numpy.ceil(maxVal)))
+            )
 
         else:  # <2s , use standard implementation from parent
             return AxisItem.tickValues(self, minVal, maxVal, size)

--- a/taurus_pyqtgraph/dateaxisitem.py
+++ b/taurus_pyqtgraph/dateaxisitem.py
@@ -81,6 +81,7 @@ class DateAxisItem(AxisItem):
             dt2 = datetime.fromtimestamp(maxVal)
         except Exception as e:
             from taurus import warning
+
             warning("Invalid range in DateTime axis: %s", e)
             return [(dx, [])]
 

--- a/taurus_pyqtgraph/dateaxisitem.py
+++ b/taurus_pyqtgraph/dateaxisitem.py
@@ -73,11 +73,16 @@ class DateAxisItem(AxisItem):
 
         maxMajSteps = int(size // self._pxLabelWidth)
 
-        dt1 = datetime.fromtimestamp(minVal)
-        dt2 = datetime.fromtimestamp(maxVal)
-
         dx = maxVal - minVal
         majticks = []
+
+        try:
+            dt1 = datetime.fromtimestamp(minVal)
+            dt2 = datetime.fromtimestamp(maxVal)
+        except Exception as e:
+            from taurus import warning
+            warning("Invalid range in DateTime axis: %s", e)
+            return [(dx, [])]
 
         if dx > 63072001:  # 3600s*24*(365+366) = 2 years (count leap year)
             d = timedelta(days=366)

--- a/tests/test_dateaxisitem.py
+++ b/tests/test_dateaxisitem.py
@@ -1,0 +1,27 @@
+from taurus.external.qt import Qt
+import taurus_pyqtgraph as tpg
+
+
+def test_tickValues(qtbot):
+    """
+    Check that the tickValues reimplementation returns the expected values
+    """
+    w = tpg.TaurusTrend()
+    qtbot.addWidget(w)
+    a = w.getPlotItem().axes["bottom"]['item']
+    # check return values in the minutes scale
+    assert a.tickValues(-65, 125, 1e3)[0] == (60.0, [-60.0, 0.0, 60.0, 120.0])
+    # check that the datetime overflows do not break the call
+    assert a.tickValues(-1e19, 0, 1e3) == [(1e19, [])]
+    assert a.tickValues(0, 1e19, 1e3) == [(1e19, [])]
+
+
+def test_tickStrings(qtbot):
+    """
+    Check that the tickStrings reimplementation returns the expected values
+    """
+    w = tpg.TaurusTrend()
+    qtbot.addWidget(w)
+    a = w.getPlotItem().axes["bottom"]['item']
+    # check return values in the minutes scale
+    assert a.tickStrings([-60.0, 120.0], None, 60) == ['00:59', '01:02']

--- a/tests/test_dateaxisitem.py
+++ b/tests/test_dateaxisitem.py
@@ -8,7 +8,7 @@ def test_tickValues(qtbot):
     """
     w = tpg.TaurusTrend()
     qtbot.addWidget(w)
-    a = w.getPlotItem().axes["bottom"]['item']
+    a = w.getPlotItem().axes["bottom"]["item"]
     # check return values in the minutes scale
     assert a.tickValues(-65, 125, 1e3)[0] == (60.0, [-60.0, 0.0, 60.0, 120.0])
     # check that the datetime overflows do not break the call
@@ -22,6 +22,6 @@ def test_tickStrings(qtbot):
     """
     w = tpg.TaurusTrend()
     qtbot.addWidget(w)
-    a = w.getPlotItem().axes["bottom"]['item']
+    a = w.getPlotItem().axes["bottom"]["item"]
     # check return values in the minutes scale
-    assert a.tickStrings([-60.0, 120.0], None, 60) == ['00:59', '01:02']
+    assert a.tickStrings([-60.0, 120.0], None, 60) == ["00:59", "01:02"]

--- a/tests/test_dateaxisitem.py
+++ b/tests/test_dateaxisitem.py
@@ -1,4 +1,3 @@
-from taurus.external.qt import Qt
 import taurus_pyqtgraph as tpg
 
 

--- a/tests/test_dateaxisitem.py
+++ b/tests/test_dateaxisitem.py
@@ -1,26 +1,102 @@
 import taurus_pyqtgraph as tpg
+from datetime import datetime
+import pytest
 
 
-def test_tickValues(qtbot):
+@pytest.mark.parametrize(
+    "val_range,expected",
+    [
+        (
+            ["2020-01-01T00:01:00.100", "2020-01-01T00:01:00.500"],
+            ["2020-01-01T00:01:00.200", "2020-01-01T00:01:00.400"],
+        ),
+        (
+            ["2020-01-01T00:00:04.900", "2020-01-01T00:00:07.900"],  # d=1s
+            [
+                "2020-01-01T00:00:05",
+                "2020-01-01T00:00:06",
+                "2020-01-01T00:00:07",
+            ],
+        ),
+        (
+            ["2020-01-01T00:00:04", "2020-01-01T00:00:37"],  # d=10s
+            [
+                "2020-01-01T00:00:10",
+                "2020-01-01T00:00:20",
+                "2020-01-01T00:00:30",
+            ],
+        ),
+        (
+            ["2020-01-01T00:05:10", "2020-01-01T00:08:50"],  # d=1m
+            ["2020-01-01T00:06", "2020-01-01T00:07", "2020-01-01T00:08",],
+        ),
+        (
+            ["2020-01-01T00:45:10", "2020-01-01T01:15:50"],  # d=10m
+            ["2020-01-01T00:50", "2020-01-01T01:00", "2020-01-01T01:10",],
+        ),
+        (
+            ["2020-01-01T00:45:10", "2020-01-01T03:15:50"],  # d=1h
+            ["2020-01-01T01:00", "2020-01-01T02:00", "2020-01-01T03:00",],
+        ),
+        (
+            ["2020-01-01T00:45:10", "2020-04-01T03:15:50"],  # d=1month
+            ["2020-02-01", "2020-03-01", "2020-04-01",],
+        ),
+        (
+            ["2020-01-01T00:45:10", "2023-04-01T03:15:50"],  # d=1y
+            ["2021-01-01", "2022-01-01", "2023-01-01",],
+        ),
+    ],
+)
+def test_tickValues(qtbot, val_range, expected):
     """
     Check that the tickValues reimplementation returns the expected values
     """
     w = tpg.TaurusTrend()
     qtbot.addWidget(w)
     a = w.getPlotItem().axes["bottom"]["item"]
-    # check return values in the minutes scale
-    assert a.tickValues(-65, 125, 1e3)[0] == (60.0, [-60.0, 0.0, 60.0, 120.0])
+    minVal, maxVal = [datetime.fromisoformat(v).timestamp() for v in val_range]
+    exp = [datetime.fromisoformat(v).timestamp() for v in expected]
+    assert a.tickValues(minVal, maxVal, 10000)[0][1] == exp
+
+
+def test_tickValues_overflow(qtbot):
+    """
+    Check that the tickValues reimplementation returns the expected values
+    """
+    w = tpg.TaurusTrend()
+    qtbot.addWidget(w)
+    a = w.getPlotItem().axes["bottom"]["item"]
     # check that the datetime overflows do not break the call
     assert a.tickValues(-1e19, 0, 1e3) == [(1e19, [])]
     assert a.tickValues(0, 1e19, 1e3) == [(1e19, [])]
 
 
-def test_tickStrings(qtbot):
+@pytest.mark.parametrize(
+    "values,expected",
+    [
+        (
+            ["2020-01-01T00:01", "2020-01-01T00:01:00.100"],
+            ["[+000000ms]", "[+100000ms]"],
+        ),
+        (["2020-01-01", "2020-01-01T00:00:05"], ["00:00:00", "00:00:05"],),
+        (["2020-01-01", "2020-01-01T00:00:30"], ["00:00:00", "00:00:30"],),
+        (["2020-01-01", "2020-01-01T00:05"], ["00:00", "00:05"]),
+        (["2020-01-01", "2020-01-01T05:00"], ["Jan/01-00h", "Jan/01-05h"],),
+        (["2020-01-01", "2020-01-05"], ["Jan/01", "Jan/05"]),
+        (["2020-01-01", "2020-05-01"], ["2020 Jan", "2020 May"]),
+        (["2020-01-01", "2023-01-01", "2050-01-01"], ["2020", "2023", "2050"]),
+    ],
+)
+def test_tickStrings(qtbot, values, expected):
     """
     Check that the tickStrings reimplementation returns the expected values
     """
     w = tpg.TaurusTrend()
     qtbot.addWidget(w)
     a = w.getPlotItem().axes["bottom"]["item"]
-    # check return values in the minutes scale
-    assert a.tickStrings([-60.0, 120.0], None, 60) == ["00:59", "01:02"]
+
+    dt = [datetime.fromisoformat(v).timestamp() for v in values]
+    spacing = dt[-1] - dt[0]
+    # check return values in the seconds scale
+    assert a.tickStrings(dt, None, spacing) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,8 @@ deps =
 commands =
     python -m pytest --basetemp={envtmpdir} .
 
+[testenv:py35]
+commands =
+    python -m pytest --forked --basetemp={envtmpdir} .
+
 


### PR DESCRIPTION
Protect DateAxisItem.tickValues against overflows

The tickValues() method uses datetime.fromtimestamp().
In some conditions, the axes range exceed the supported
datetime range and produces an exception. Handle it by
returning an empty list instead of raising the exception.

Fixes #18